### PR TITLE
Adding step to IDM role to ensure systems are registered

### DIFF
--- a/roles/idm/tasks/ensure_system_registered.yml
+++ b/roles/idm/tasks/ensure_system_registered.yml
@@ -1,0 +1,10 @@
+---
+- name: Register to Red Hat Portal {{ inventory_hostname }}
+  ansible.builtin.include_role:
+    name: redhat.rhel_system_roles.rhc
+  vars:
+    rhc_auth:
+      activation_keys:
+        keys:
+          - "{{ activation_key_vault }}"
+    rhc_organization: "{{ org_number_vault }}"

--- a/roles/idm/tasks/main.yml
+++ b/roles/idm/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 - name: "Ensure prerequisites are applied"
+  ansible.builtin.include_tasks: ensure_system_registered.yml
+
+- name: "Ensure prerequisites are applied"
   ansible.builtin.include_tasks: ensure_prerequisites.yml
 
 - name: "Apply the ipaserver role"

--- a/roles/idm/tasks/main.yml
+++ b/roles/idm/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Ensure prerequisites are applied"
+- name: "Ensure system is registered"
   ansible.builtin.include_tasks: ensure_system_registered.yml
 
 - name: "Ensure prerequisites are applied"


### PR DESCRIPTION
When first running the IdM role the prerequisite task, `ensure_prerequisites.yml`, enables repositories. If a system has not been registered, this will fail.

When configuring the rhis_builder_vault.yml file, there are variables for an activation key and the organization ID.

Using these two already defined variables, we can leverage the redhat.rhel_system_roles.rhc role to register the system to the Red Hat portal.